### PR TITLE
Setup project - Update podfile and dependencies

### DIFF
--- a/JetDevsHomeWork/AppDelegate.swift
+++ b/JetDevsHomeWork/AppDelegate.swift
@@ -23,4 +23,3 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 		return true
 	}
 }
-

--- a/JetDevsHomeWork/ViewController.swift
+++ b/JetDevsHomeWork/ViewController.swift
@@ -13,7 +13,4 @@ class ViewController: UIViewController {
 		super.viewDidLoad()
 		// Do any additional setup after loading the view.
 	}
-
-
 }
-

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Kingfisher (7.1.0)
+  - Kingfisher (7.10.1)
   - RxSwift (5.1.3)
   - SnapKit (5.0.1)
   - SwiftLint (0.44.0)
@@ -18,11 +18,11 @@ SPEC REPOS:
     - SwiftLint
 
 SPEC CHECKSUMS:
-  Kingfisher: cdabaf49be7ee7cc124f0f276b355edf61903cf8
+  Kingfisher: bc5abe80a8e0144537ef1dd5a0b2621b04f7f439
   RxSwift: 915abbdfb62214aa89ccd0b194d44fb478019b27
   SnapKit: 97b92857e3df3a0c71833cce143274bf6ef8e5eb
   SwiftLint: e96c0a8c770c7ebbc4d36c55baf9096bb65c4584
 
 PODFILE CHECKSUM: 48cd3f9752df43d8aa0ab09bec23e199b48cd496
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.12.1


### PR DESCRIPTION
1. Fix Podfile issue with reinstall
2. Using Xcode 15.2
3. Update the minimum target from iOS 8 to12 in below two dependencies as per the Xcode error: 
- RxSwift 
- Snapkit

Checklist:
- [x] Project compiled
- [x] Project run on simulator